### PR TITLE
Add sdw-dom0-config 0.5.6-rc1

### DIFF
--- a/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.6-0.rc1.1.fc25.noarch.rpm
+++ b/workstation/dom0/f25/securedrop-workstation-dom0-config-0.5.6-0.rc1.1.fc25.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22202403330530ae585c03c16b77cfc39a1e2c2c02163110c831d299f9ef3370
+size 123047


### PR DESCRIPTION


###
Name of package: `securedrop-workstation-dom0-config`, v0.5.6-rc1


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.5.6-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/066292027b15c9da38af831bd7eb6901d644f3e5
- [ ] CI is passing, the rpm is properly signed with the test key
- [ ] Unsigned RPM after running `rpm --delsign` on the signed RPM results in the checksum found in the build logs
