### PR TITLE
Add securedrop-workstation-dom0-config 0.8.0-rc1

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-0.rc1.1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-0.rc1.1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:535bcf3a80e90e37f11e90693c76f4eaab670ef0689b908465ebf57f941b09d4
+size 117000


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-workstation/issues/866>.

###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.8.0-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/08b5f09f4871253876e92a12f671d00e9df58fe1
