### PR TITLE
Add securedrop-workstation-dom0-config 0.8.0-rc2

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-0.rc2.1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.8.0-0.rc2.1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eddba4d4d3255bfe5860aa4bcdc068729a5e71866a09dd0063855ddc2627c830
+size 112820


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-workstation/issues/866>.

###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.8.0-rc2
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/20b7e8cf4ee1963159bc8841580f8fbd44a71356
