### PR TITLE
Add qubes-template-securedrop-workstation-bullseye-4.1-20230615

### DIFF
--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea46f6fd9eab32df46b52798d47b46965c0950e568349b36ce9b430f56b38981
+size 1039498318


### PR DESCRIPTION
###
Name of package: qubes-template-securedrop-workstation-bullseye-4.1

Towards: https://github.com/freedomofpress/securedrop-workstation/issues/887 
WIP: needs testing and may need rebuilding

### Test plan
- [x] Artifact installs in dom0
- [x] `sdw-admin --apply` completes successfully
- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/a3539dcfbfe05fe98f2f21657c38a1519f5a508c
