### PR TITLE
Adds sdw-dom0-config 0.9.0-rc2 RPM

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0rc2-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0rc2-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca778deb99509924abbaced3d5620d2e471b27fc93fdc2620466f6f60c138acc
+size 95363


### PR DESCRIPTION
###
Package: workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0rc2-1.fc32.noarch.rpm


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.9.0-rc2
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/c0d9a338a424a9d25869fb9bb379c7a099c9c862