### PR TITLE
Strip signatures from RPMs

### DIFF
--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206132300.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206132300.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d94a4f1e2afc51a220ae8ac5a08a97ba4698efb4badcfb0182d0c061368eee9e
+oid sha256:11811302d5e7fc8408a883a02a833b44f352705a2b59a3834bd39a9231ada2f1
 size 897266789

--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:193150c1fa2902522b2689e4f0d7f615c232caf666c9bafccaa28c7faf4e811e
+oid sha256:43e4cdc74963014df0d5c82dcfff0311fa7e0d21c7c9b3981e7517482211359c
 size 894940033

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.0-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.0-1.fc32.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd47f0ea662f2698fd7a6ec86aa168a5a108991f3b25d70af724271d30bbbe9e
+oid sha256:af1bccfc8312016a38afcde297d5bfa699d466ea2119080310487f6d2df2e89a
 size 127731

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.1-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.7.1-1.fc32.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52dad009618bfb362e02baf8d8ddd098646a463c8b5cf4d9b58b251ef8313edf
+oid sha256:96f404e05940e3cb44e1074264195d5c85d29cc3fa4fac73f0121c55e00f4d01
 size 117456


### PR DESCRIPTION
RPMs in this repository are no longer supposed to be signed but these pre-date that. But having them signed means that different RPM tooling will try to validate the signature, which fails if you don't have the test repository key imported and it's just easier to remove the remaining signatures and assume the packages will be unsigned going forwards.


## Test plan:
* [x] Check out main, run `rpm --delsign *` using RPM 4.18 (F38 or D12) and get the same checksums:
```
11811302d5e7fc8408a883a02a833b44f352705a2b59a3834bd39a9231ada2f1  qubes-template-securedrop-workstation-bullseye-4.0.6-202206132300.noarch.rpm
43e4cdc74963014df0d5c82dcfff0311fa7e0d21c7c9b3981e7517482211359c  qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
af1bccfc8312016a38afcde297d5bfa699d466ea2119080310487f6d2df2e89a  securedrop-workstation-dom0-config-0.7.0-1.fc32.noarch.rpm
96f404e05940e3cb44e1074264195d5c85d29cc3fa4fac73f0121c55e00f4d01  securedrop-workstation-dom0-config-0.7.1-1.fc32.noarch.rpm
```