### PR TITLE
Add 0.10.0-rc1 dom0 rpm

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0rc1-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0rc1-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:169645284dc2772251ddf2c8e119b275182bc22297c48ac059227756d82e9edd
+size 95502


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config-0.10.0rc1-1.fc32.noarch.rpm


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.10.0-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/972ba97346615a4f130ad2fdee21941830db90c7