### PR TITLE
addd 0.10.0-rc2 sdw dom0 rpm

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0rc2-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0rc2-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33a5a6341324712699d0b99a01a831be21ab2236adbaadb05f8dbdbe281b105f
+size 95600


### PR DESCRIPTION
###
Name of package:


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.10.0-rc2
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/dc82109f8132e01c1bb4e7ac4373cd4f3798c93c