### PR TITLE
Run cleanup workflow on main pushes

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,8 @@
 name: Remove old packages
 on:
-  schedule:
-    - cron: "0 8 * * *"
+  push:
+    branches:
+      - main
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Follow-up to https://github.com/freedomofpress/securedrop-yum-test/pull/55; this is a bit cleaner than syncing up cronjobs and mirrors the configuration for `securedrop-apt-test`