### PR TITLE
adding older f32 package in f37/ distro, to allow for strict checking in yum.repo.d

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-0.9.0rc2-1.fc32.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-0.9.0rc2-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca778deb99509924abbaced3d5620d2e471b27fc93fdc2620466f6f60c138acc
+size 95363


### PR DESCRIPTION
https://github.com/freedomofpress/securedrop-workstation/pull/1054 adds strict checking for the existence of the workstation yum repo - but yum-test.securedrop.org currently does not have a f37/ subdirectory.

If we build an RC off main as is, it will be overridden by nightlies, so this just adds the 0.9.0rc1 f32 package instead.

