### PR TITLE
Add securedrop-workstation-dom0-config 1.0.0-rc1

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-0.9.0rc2-1.fc32.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-0.9.0rc2-1.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca778deb99509924abbaced3d5620d2e471b27fc93fdc2620466f6f60c138acc
-size 95363

--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0rc1-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0rc1-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f511079679879ae92c37906331227dd25a775868524e608826ab09d851e0914
+size 92427


### PR DESCRIPTION
Name of package: securedrop-workstation-dom0-config 1.0.0-rc1

Refs <https://github.com/freedomofpress/securedrop-workstation/issues/1103>.

### Test plan

- [ ] Able to reproduce build locally with exact same checksum
- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.0.0-rc1
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/315a07dfc7c116d5b1fed7f5753beffe26e3b38d
