### PR TITLE
Add sdw-dom0-config 0.11.1-rc1

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1rc1-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1rc1-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e78ecbf77b785950c0d6411b52ca628e286bab30709a2759dfa8298a9bd95c92
+size 101997


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config-0.11.1-rc1

Refs: https://github.com/freedomofpress/securedrop-workstation/issues/1057

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.11.1-rc1
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/da4f266
- [ ] Build is reproducible from 0.11.1-rc1 tag 

