### PR TITLE
Add securedrop-workstation-dom0-config-0.11.1-rc2

### DIFF
--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1rc2-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1rc2-1.fc32.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfc3e7967463ad39e3cd2ba7d838025852da39296d13b471224ba16d3878808f
+size 102043


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config-0.11.1-rc2

Supersedes https://github.com/freedomofpress/securedrop-yum-test/pull/59
Refs https://github.com/freedomofpress/securedrop-workstation/issues/1057

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/0.11.1-rc2
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/3a5db64
- [x] Build is reproducible (hell yeah!) from the tag mentioned above
