### PR TITLE
Add securedrop-workstation-dom0-config 1.0.0-rc2

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0rc2-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0rc2-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d4c0f60a1cd5f8bfd8b9e6b86e6fcb99d5af7f5c9ea911a0ca4693d8a112a0b
+size 92490


### PR DESCRIPTION

###
Name of package: securedrop-workstation-dom0-config

Refs <https://github.com/freedomofpress/securedrop-workstation/issues/1103>.


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.0.0-rc2
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/c12d94d38503d789aef0c99dba291675f7d53c0a
