### PR TITLE
Add sdw-dom0-config 1.0.0-rc3

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0rc3-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.0.0rc3-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:906d6887c670dc7c057608eb4c90f35c0231b52f18f30627aa46b0c81f4144ff
+size 92532


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-workstation/issues/1103>.

###
Name of package: 

securedrop-workstation-dom0-config


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.0.0-rc3
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/ee21484830ec21a7b39bc05bb400d43acb7b9e82
- [x] reproducing the build works exactly
