### PR TITLE
Add securedrop-workstation-dom0-config-1.1.0-rc3

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0rc3-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0rc3-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a720fe8518fc861ae640c13c3a5ed9a719f3787b12a92a0bfa6a7155ad9f3b4
+size 93458


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config-1.1.0-rc3

Refs https://github.com/freedomofpress/securedrop-workstation/issues/1209

### Test plan

- [x] RPM build is independently reproducible
- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.1.0-rc3
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/972ea6c9c9a35d687ee0296694b2a810d3426085
