### PR TITLE
Add SecureDrop Workstation 1.1.0-rc4

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0rc4-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.1.0rc4-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:385008f8025fa6b2b67aec02c789dc712971a79f07aa4a45d892878f96ba1cc9
+size 93446


### PR DESCRIPTION
###
Name of package:
SecureDrop Workstation 1.1.0-rc4 

### Test plan

- [x] Signed commit
- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.1.0-rc4
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/7b7e83e2bc95e36b0b58386d48cb72bc05a0bb17
- [x] Build independently reproduced with same hashes
