### PR TITLE
Remove Qubes 4.1 (f32) packages

### DIFF
--- a/workstation/dom0/f32-nightlies/securedrop-updater-0.7.0-0.20240406060342.fc32.noarch.rpm
+++ b/workstation/dom0/f32-nightlies/securedrop-updater-0.7.0-0.20240406060342.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:923c410c571a8284f3a361c3a3c82ce1ed415d755178e7b124578c7eed22cee3
-size 50395

--- a/workstation/dom0/f32-nightlies/securedrop-updater-0.7.0-0.20240407060354.fc32.noarch.rpm
+++ b/workstation/dom0/f32-nightlies/securedrop-updater-0.7.0-0.20240407060354.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c3f925e18f25a2d0b1fab0489f290cb2b950fdd78112aaebc1633f96df1d1ef
-size 50398

--- a/workstation/dom0/f32-nightlies/securedrop-updater-0.7.0-0.20240408060346.fc32.noarch.rpm
+++ b/workstation/dom0/f32-nightlies/securedrop-updater-0.7.0-0.20240408060346.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85df632af1a8f4700030393fee25396ecb585307e78c556601326b62b931841a
-size 50396

--- a/workstation/dom0/f32-nightlies/securedrop-updater-0.7.0-0.20240409060341.fc32.noarch.rpm
+++ b/workstation/dom0/f32-nightlies/securedrop-updater-0.7.0-0.20240409060341.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:038ae246f18a61f01bcd7430a0401e1e3418861b63fd9d436df958fd6939b083
-size 50396

--- a/workstation/dom0/f32-nightlies/securedrop-workstation-dom0-config-0.10.0-0.20240406060338.fc32.noarch.rpm
+++ b/workstation/dom0/f32-nightlies/securedrop-workstation-dom0-config-0.10.0-0.20240406060338.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:030b093b96880dbbb34ebcc9d4ec5bab5ee619dae73179d9b1636b88d9867582
-size 97155

--- a/workstation/dom0/f32-nightlies/securedrop-workstation-dom0-config-0.10.0-0.20240407060343.fc32.noarch.rpm
+++ b/workstation/dom0/f32-nightlies/securedrop-workstation-dom0-config-0.10.0-0.20240407060343.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c75d66eba3f0b3092c491c45659df33064e9b51d30986161d58ae6207bb0c562
-size 97164

--- a/workstation/dom0/f32-nightlies/securedrop-workstation-dom0-config-0.10.0-0.20240408060343.fc32.noarch.rpm
+++ b/workstation/dom0/f32-nightlies/securedrop-workstation-dom0-config-0.10.0-0.20240408060343.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3954a7f2360198e8114ab5f92bdd48d68a4ec532af47b1dd1d2bf9934110b318
-size 97155

--- a/workstation/dom0/f32-nightlies/securedrop-workstation-dom0-config-0.10.0-0.20240409060346.fc32.noarch.rpm
+++ b/workstation/dom0/f32-nightlies/securedrop-workstation-dom0-config-0.10.0-0.20240409060346.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4113e48e59bf1f952426c941cdf387887766dd8fbe2648af20ace4ac13e1b9a
-size 97165

--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206132300.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206132300.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11811302d5e7fc8408a883a02a833b44f352705a2b59a3834bd39a9231ada2f1
-size 897266789

--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.0.6-202206302135.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43e4cdc74963014df0d5c82dcfff0311fa7e0d21c7c9b3981e7517482211359c
-size 894940033

--- a/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
+++ b/workstation/dom0/f32/qubes-template-securedrop-workstation-bullseye-4.1-202306151618.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea46f6fd9eab32df46b52798d47b46965c0950e568349b36ce9b430f56b38981
-size 1039498318

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0rc1-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0rc1-1.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:169645284dc2772251ddf2c8e119b275182bc22297c48ac059227756d82e9edd
-size 95502

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0rc2-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.10.0rc2-1.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33a5a6341324712699d0b99a01a831be21ab2236adbaadb05f8dbdbe281b105f
-size 95600

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1rc2-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.11.1rc2-1.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfc3e7967463ad39e3cd2ba7d838025852da39296d13b471224ba16d3878808f
-size 102043

--- a/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0rc2-1.fc32.noarch.rpm
+++ b/workstation/dom0/f32/securedrop-workstation-dom0-config-0.9.0rc2-1.fc32.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca778deb99509924abbaced3d5620d2e471b27fc93fdc2620466f6f60c138acc
-size 95363


### PR DESCRIPTION
Remove the Qubes 4.1 (f32) packages since it's very EOL and also because the template RPMs are giant.