### PR TITLE
Add SecureDrop Workstation 1.2.0-rc1 release

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.2.0rc1-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.2.0rc1-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15b5089bad7bbacce833960bad42e5fc040fe1caf6478ef338b492993836fba7
+size 93787


### PR DESCRIPTION
Build logs pushed in https://github.com/freedomofpress/build-logs/commit/5b9c19838bd2ccbd1ab403d64b6848e34237d199

Refs https://github.com/freedomofpress/securedrop-workstation/issues/1298

###
Name of package: securedrop workstation 1.2.0-rc1


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/1234
