### PR TITLE
Add securedrop-workstation-keyring-{dev,staging} packages

### DIFF
--- a/workstation/dom0/f37-nightlies/securedrop-workstation-keyring-dev-0.1.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37-nightlies/securedrop-workstation-keyring-dev-0.1.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b192af6ae40c1099bb4c8800133472fa054d94bb02e231da7d4420c46df3cce
+size 10652

--- a/workstation/dom0/f37/securedrop-workstation-keyring-staging-0.1.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-keyring-staging-0.1.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d686f32bb6134d5e3f8c35c129e642f1edbc0c67d172a888fb11f8f892c7a5b3
+size 10657


### PR DESCRIPTION
###
Name of package:
securedrop-workstation-keyring-dev (f37 nightlies)  https://github.com/freedomofpress/build-logs/commit/3faf29a5890f9fed58a081fbe23df9e3f7055c30
securedrop-workstation-keyring-staging (f37) https://github.com/freedomofpress/build-logs/commit/e50a75b3f442424ea3e287851cb56f304267e8b5


### Test plan (x2)
- [x] Reproduce via `make build-rpm-dev` , `make build-rpm-staging`, get same hashes as above
- [x] Build logs and buildinfo are included (see above; note, we haven't previously included buildinfo for rpms, but we might as well)
- [x] Maintainer review and sign off on `dev`, `staging` branch: one commit different from main, signed by maintainer; relevant changes only
- [x] Package installs successfully
- [x] Upon package install, /etc/pki/rpm-gpg conains RPM-GPG-KEY-securedrop-workstation-test, our test key, and /etc/yum.repos.d/securedrop-workstation-dom0-dev.repo, a repo file pointing at yum-test nightlies for the dom0 config rpm 
- [x] After installing dev package, `sudo qubes-dom0-update --action=info securedrop-workstation-dom0-config` shows the latest nightly (for example:)
```
SecureDrop Workstation Qubes dom0 repo                                                 479  B/s | 2.6 kB     00:05    
Available Packages
Name         : securedrop-workstation-dom0-config
Version      : 1.3.0rc1
Release      : 0.20250806060258.fc37
Architecture : noarch
Size         : 94 k
Source       : securedrop-workstation-dom0-config-1.3.0rc1-0.20250806060258.fc37.src.rpm
Repository   : securedrop-workstation-dom0
Summary      : SecureDrop Workstation
URL          : https://github.com/freedomofpress/securedrop-workstation
License      : AGPLv3
Description  : This package contains VM configuration files for the Qubes-based
             : SecureDrop Workstation project. The package should be installed
             : in dom0, or AdminVM, context, in order to manage updates to the VM
             : configuration over time.
```
- [x] After installing staging package, `--action=info` shows latest available staging (eg today, although this will change when the 1.3.0 rc1 release package is available):
```
Available Packages
Name         : securedrop-workstation-dom0-config
Version      : 1.2.0rc1
Release      : 1.fc37
Architecture : noarch
Size         : 92 k
Source       : securedrop-workstation-dom0-config-1.2.0rc1-1.fc37.src.rpm
Repository   : securedrop-workstation-dom0
Summary      : SecureDrop Workstation
URL          : https://github.com/freedomofpress/securedrop-workstation
License      : AGPLv3
Description  : This package contains VM configuration files for the Qubes-based
             : SecureDrop Workstation project. The package should be installed
             : in dom0, or AdminVM, context, in order to manage updates to the VM
             : configuration over time.
```
- [ ] With keyring-dev and keyring-staging installed together, the newest version of the dom0 config package is shown in, and the notice `Repository securedrop-workstation-dom0 is listed more than once in the configuration` is displayed on `dnf info securedrop-workstation-dom0-config` 