### PR TITLE
Add securedrop-workstation-keyring-0.1.0 (prod) rpm [yum-test only] 

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-keyring-0.1.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-keyring-0.1.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af18b5e949da0b8e4ceb9dfcd6644883a30cd9ad3fd48148edbd232ccdac5beb
+size 12345


### PR DESCRIPTION

###
Name of package: securedrop-workstation-keyring

Note: yum-test only! per https://github.com/freedomofpress/securedrop-workstation/pull/1210#discussion_r2289264683

### Test plan

- [ ] Reproduce with `git tag -v 0.1.0 && git checkout 0.1.0 && make build-rpm` in keyring repo
- [ ] Tag in securedrop-workstation repository is correct: (note: maintainer signed tag) https://github.com/freedomofpress/securedrop-workstation-keyring/releases/tag/0.1.0 
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/a298f29 + https://github.com/freedomofpress/build-logs/commit/bfffa90 (this one shows the 0.1.0 tag + reproducibility; I realized I checked out `latest` in the first build logs, so attaching both logs to show they're built from the same commit.)
