### PR TITLE
Publish sdw-keyring-0.1.0 to f37-nightlies

### DIFF
--- a/workstation/dom0/f37-nightlies/securedrop-workstation-keyring-0.1.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37-nightlies/securedrop-workstation-keyring-0.1.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83f953010991ac75605f5a94903b139b03885f54dda60a1bf4ee5f1b211e3cfe
+size 12921


### PR DESCRIPTION
###
Name of package:
securedrop-workstation-keyring-0.1.0

### Test plan

See https://github.com/freedomofpress/securedrop-yum-test/commit/82fca92951cca6c28f75e42f83a634b6635d716a (same artifact, same build logs)

Note: publishing to f37-nightlies and yum-test in general is only needed while packages are pending qubes-contrib inclusion.