### PR TITLE
Add securedrop-workstation-keyring 0.2.0 to nightlies

### DIFF
--- a/workstation/dom0/f37-nightlies/securedrop-workstation-keyring-0.2.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37-nightlies/securedrop-workstation-keyring-0.2.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54afaedbf6ca0d0e03140a7207f7cc7c091accc4600a260f3dd1c3664f5f1ff4
+size 12471


### PR DESCRIPTION


###
Name of package:
securedrop-workstation-keyring-0.2.0
Note:  developer-facing only, will only be published on yum-test.

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation-keyring/releases/tag/0.2.0 (maintainer-signed tag; see above)
- [x] https://github.com/freedomofpress/build-logs/commit/6804ed45c624bbf6eb0c3d767fa480bb2297cd3f
