### PR TITLE
Add SecureDrop Workstation 1.4.0-rc1

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.4.0rc1-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.4.0rc1-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df26061e64cc3436224758026ecf7d832f9d89e4e28175e53c14ee84536f7031
+size 96081


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.4.0-rc1
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/077574339b38e3e4391962fee60b47140330e3e1
