### PR TITLE
Add securedrop-workstation-keyring-0.2.0-1 from Qubes Contrib

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-keyring-0.2.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-keyring-0.2.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce9beeecf20d568c27635066cad38326b9b281a094a3a9f12f1f02a129746311
+size 16618


### PR DESCRIPTION
This is a copy of <https://contrib.qubes-os.org/yum/r4.2/current/host/fc37/rpm/securedrop-workstation-keyring-0.2.0-1.fc37.noarch.rpm> with `rpm --delsign` run on it.

Refs <https://github.com/freedomofpress/securedrop-workstation-keyring/issues/34>.
