### PR TITLE
Add SecureDrop Workstation 1.5.0-rc1

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.5.0rc1-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.5.0rc1-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5daec143a834a45be532b78a5bf9a26d2e9c0bb0fba3faa7a6831dfbf1a50b12
+size 94751


### PR DESCRIPTION

###
Name of package: `securedrop-workstation-dom0-config`


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.5.0-rc1
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/32b3955fe56ef3222f59ae19aa5bf3b5f023221b
