### PR TITLE
Add securedrop-workstation-dom0-config 1.6.0-rc1

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.0rc1-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.0rc1-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8007b9cc6db53ebec0fa26bff9694bd85e84f157203017f5ced6a15255f4dad0
+size 95807


### PR DESCRIPTION
Refs <https://github.com/freedomofpress/securedrop-workstation/issues/1563>.

###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.6.0-rc1
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/e7e21b18e1f4e4f17922bc2be8ab5de8576940cb
- [x] Build is reproducible
