### PR TITLE
Add prod keyring to nightlies repos

### DIFF
--- a/workstation/dom0/f37-nightlies/securedrop-workstation-keyring-0.3.0-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37-nightlies/securedrop-workstation-keyring-0.3.0-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eb8601d0b8ec34e881e65c0623773a77fb0e6db84467305c28128b4ff6576b1
+size 17011

--- a/workstation/dom0/f41-nightlies/securedrop-workstation-keyring-0.3.0-1.fc41.noarch.rpm
+++ b/workstation/dom0/f41-nightlies/securedrop-workstation-keyring-0.3.0-1.fc41.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d6d16646636eef124476ad78e1a61d832230ba7cb40d08e44097e6440268842
+size 17011


### PR DESCRIPTION
The keyring 0.3.0 release candidates were removed recently, but this apparently [cannot be removed yet](https://github.com/freedomofpress/securedrop-yum-test/pull/90#issuecomment-3984245249).

I have copied the 0.3.0 releases we uploaded to the testing repo and stripped it's signature so it can be signed again.
 
###
Name of package: securedrop-workstation-keyring 0.3.0


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/1234
