### PR TITLE
Add securedrop-workstation-dom0-config-1.6.0rc2-1.fc37.noarch.rpm

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.0rc2-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.0rc2-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42a92f25e5809eebcdc94f9aa949078227e2b77b6aaa8231be994b2e3583bbb7
+size 96317


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.6.0-rc2
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/c46996eff709c394d071c44df1d039110290ab5d
- [x] Build is reproducible
