### PR TITLE
Add SecureDrop Workstation 1.6.0-rc3

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.0rc3-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.0rc3-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:906bebef5ba50c0ea1ea31fc42cf9fdf55042d6776227568081ed3297f17f0a0
+size 96405


### PR DESCRIPTION
###
Name of package: `securedrop-workstation-dom0-config-1.6.0rc3`

Refs: https://github.com/freedomofpress/securedrop-workstation/issues/1563

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.6.0-rc3
- [x] Build logs are included:https://github.com/freedomofpress/build-logs/commit/7431c156e8bf25ceb8f6b044d6a6d09d8e923908
- [x] build is 100% reproducible
