### PR TITLE
Add SecureDrop Workstation 1.7.0-rc1

### DIFF
--- a/workstation/dom0/f41/securedrop-workstation-dom0-config-1.7.0rc1-1.fc41.noarch.rpm
+++ b/workstation/dom0/f41/securedrop-workstation-dom0-config-1.7.0rc1-1.fc41.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81991f5aca609b05ddee18803feba2d0521eb89eb3a402131e28b6ee1e2b41a0
+size 95899


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.7.0-rc1
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/55ef2325625ba7703a8c7e6872d12b87a5f41ed2
- [x] Build is 100% reproducible
