### PR TITLE
SecureDrop Workstation 1.7.0rc2

### DIFF
--- a/workstation/dom0/f41/securedrop-workstation-dom0-config-1.7.0rc2-1.fc41.noarch.rpm
+++ b/workstation/dom0/f41/securedrop-workstation-dom0-config-1.7.0rc2-1.fc41.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49655aaf3ad887f078254a11bff6e75c067788a1768ddfed6d8ffff33c13ba80
+size 96023


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config-1.7.0rc2


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.7.0-rc2
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/3913cbe43f6237e09ec8c0413cabc4797430e33e
