### PR TITLE
Add SecureDrop Workstation 1.6.1-rc1

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.1rc1-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.1rc1-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7adf2cfed1b27d461f49211a637843687df28b5e3bf674b6eea9afe5166347b4
+size 100104


### PR DESCRIPTION
### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.6.0-rc1
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/d22f1e91e41a13688ddf89abc48f6254ad5fd944
- [x] RPM is reproducible
