### PR TITLE
Add SecureDrop Workstation 1.6.2-rc1

### DIFF
--- a/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.2rc1-1.fc37.noarch.rpm
+++ b/workstation/dom0/f37/securedrop-workstation-dom0-config-1.6.2rc1-1.fc37.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc7eee6d9a984f05afec7bc5edf03988d7a40f7928a65f5e50a02a7372ea61a4
+size 99982


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.6.2-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/e7f123e
