### PR TITLE
Add reproduction steps to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,4 @@ Name of package:
 
 - [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/x.y.z
 - [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/1234
+- [ ] `make build-rpm` run by someone else produces the same hashes to confirm reproducibility


### PR DESCRIPTION
Copied from what we have in yum-prod. This was apparently missing, even though we did it in practice.