### PR TITLE
Add SecureDrop Workstation 1.7.1-rc1

### DIFF
--- a/workstation/dom0/f41/securedrop-workstation-dom0-config-1.7.1rc1-1.fc41.noarch.rpm
+++ b/workstation/dom0/f41/securedrop-workstation-dom0-config-1.7.1rc1-1.fc41.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4d791d42e87f0638b511cce97423622ce4c5d229261f371fe4fbf9c6a969df9
+size 95733


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.7.1-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/d7e9fca
