### PR TITLE
Add SecureDrop workstation 1.8.0-rc1

### DIFF
--- a/workstation/dom0/f41/securedrop-workstation-dom0-config-1.8.0rc1-1.fc41.noarch.rpm
+++ b/workstation/dom0/f41/securedrop-workstation-dom0-config-1.8.0rc1-1.fc41.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf371a96cc02f7fc578a3d25c6e4532cf3be77dad0803bb4763143d0a5665237
+size 100330


### PR DESCRIPTION
###
Name of package: securedrop-workstation-dom0-config-1.8.0-rc1


### Test plan

- [ ] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.8.0-rc1
- [ ] Build logs are included: https://github.com/freedomofpress/build-logs/commit/0257d6d6
- [ ] `make build-rpm` run by someone else produces the same hashes to confirm reproducibility