### PR TITLE
Add SecureDrop Workstation 1.8.0-rc2

### DIFF
--- a/workstation/dom0/f41/securedrop-workstation-dom0-config-1.8.0rc2-1.fc41.noarch.rpm
+++ b/workstation/dom0/f41/securedrop-workstation-dom0-config-1.8.0rc2-1.fc41.noarch.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:176edeeb0c748b2f3aae5038a52c04dacf370bb9f042dcfda44454bc3cd86bcf
+size 100467


### PR DESCRIPTION

### Test plan

- [x] Tag in securedrop-workstation repository is correct: https://github.com/freedomofpress/securedrop-workstation/releases/tag/1.8.0-rc2
- [x] Build logs are included: https://github.com/freedomofpress/build-logs/commit/9fdb7d3721d20b3c5860ebb3f28ebbad56598f4c
- [x] `make build-rpm` run by someone else produces the same hashes to confirm reproducibility